### PR TITLE
Configuration

### DIFF
--- a/cmd/tugboat/main.go
+++ b/cmd/tugboat/main.go
@@ -11,7 +11,7 @@ func main() {
 	cli := commands.NewCli()
 
 	if err := cli.Execute(); err != nil {
-		fmt.Println(err)
+		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.15.0
 	github.com/tonistiigi/go-rosetta v0.0.0-20220804170347-3f4430f2d346
+	golang.org/x/text v0.5.0
 )
 
 require (
@@ -45,7 +46,6 @@ require (
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/net v0.4.0 // indirect
 	golang.org/x/sys v0.3.0 // indirect
-	golang.org/x/text v0.5.0 // indirect
 	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.1.12 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect

--- a/internal/cli/cmd/build/cmd.go
+++ b/internal/cli/cmd/build/cmd.go
@@ -34,7 +34,7 @@ func NewBuildCommand(globalFlags *flags.GlobalFlagGroup) *cobra.Command {
 var buildDescription = `Build an image from a Dockerfile`
 
 func runBuild(opts *flags.Options) error {
-	log.Debugf("Build Options: %+v\n", opts)
+	log.Debugf("Build Options: %+v", opts)
 
 	ctx := context.Background()
 	client, err := docker.NewClientFromEnv()

--- a/internal/cli/cmd/root/cmd.go
+++ b/internal/cli/cmd/root/cmd.go
@@ -1,18 +1,40 @@
 package root
 
 import (
+	"os"
+	"tugboat/internal/config"
 	"tugboat/internal/pkg/flags"
+	"tugboat/internal/pkg/logging"
 	"tugboat/internal/version"
 
+	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func NewRootCommand(globalFlags *flags.GlobalFlagGroup) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:           "tugboat",
-		Version:       version.GetFullVersionWithArch(),
-		Short:         "Build multi-arch images",
-		Long:          rootDescription,
+		Use:     "tugboat",
+		Version: version.GetFullVersionWithArch(),
+		Short:   "Build multi-arch images",
+		Long:    rootDescription,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			// Load the config
+			configPath := viper.GetString(flags.ConfigFileFlag.ConfigName)
+			if err := config.LoadConfig(configPath); err != nil {
+				return err
+			}
+
+			globalOptions := globalFlags.ToOptions()
+
+			logging.Initialize(os.Stderr, globalOptions.Debug)
+
+			if globalOptions.DryRun {
+				log.Warn("Dry run in progress, nothing will be executed")
+			}
+
+			return nil
+		},
 		SilenceUsage:  true,
 		SilenceErrors: true,
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"io/fs"
+
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/viper"
+)
+
+func LoadConfig(configFile string) error {
+	validFileNames := []string{"tugboat", ".tugboat"}
+
+	for _, file := range validFileNames {
+		viper.SetConfigName(file)
+		viper.SetConfigType("yaml")
+
+		validPaths := []string{".", "./ci", "./.ci"}
+		for _, path := range validPaths {
+			viper.AddConfigPath(path)
+		}
+
+		if configFile != "" {
+			viper.SetConfigFile(configFile)
+		}
+
+		// Process the configuration
+		if err := viper.ReadInConfig(); err != nil {
+			if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+				// Config file not found; ignore error as we will also pull from flags and env variables
+				log.Debugf("No configuration located: %v", err.(viper.ConfigFileNotFoundError))
+			} else if _, ok := err.(*fs.PathError); ok {
+				log.Warnf("No configuration file located for the provided config: %v", configFile)
+			} else {
+				// Config file was found but another error was produced
+				return errors.Errorf("loading the config file failed: %v", err)
+			}
+		}
+	}
+
+	log.Debugf("Loaded '%v'", configFile)
+
+	return nil
+}

--- a/internal/pkg/logging/formatter.go
+++ b/internal/pkg/logging/formatter.go
@@ -1,0 +1,25 @@
+package logging
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type logTextFormatter log.TextFormatter
+
+// Set the logging format to output colored log text
+func (f *logTextFormatter) Format(entry *log.Entry) ([]byte, error) {
+	var levelColor int
+	switch entry.Level {
+	case log.DebugLevel, log.TraceLevel:
+		levelColor = 30 // gray
+	case log.WarnLevel:
+		levelColor = 33 // yellow
+	case log.ErrorLevel, log.FatalLevel, log.PanicLevel:
+		levelColor = 31 // red
+	default:
+		levelColor = 36 // blue
+	}
+	return []byte(fmt.Sprintf("\x1b[%dm%s\x1b[0m\n", levelColor, entry.Message)), nil
+}

--- a/internal/pkg/logging/logging.go
+++ b/internal/pkg/logging/logging.go
@@ -1,0 +1,37 @@
+package logging
+
+import (
+	"io"
+	"os"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// Initialize takes an io writer to output (defaulting to os.Stderr when nil)
+// and a debug option to set the log level to debug.
+func Initialize(wr io.Writer, isDebug bool) {
+	if wr == nil {
+		wr = os.Stderr
+	}
+
+	log.SetOutput(wr)
+	log.SetFormatter(&logTextFormatter{})
+
+	level := "info"
+	if isDebug {
+		level = "debug"
+	}
+	SetLevel(level)
+}
+
+// SetLevel parses a string and attempts to set the logging level
+// using that string. If the string is not valid the info log level will
+// be used as a fall back.
+func SetLevel(level string) {
+	lvl, err := log.ParseLevel(level)
+	if err != nil {
+		lvl = log.InfoLevel
+		log.Warnf("failed to parse log-level '%s', defaulting to 'info'", level)
+	}
+	log.SetLevel(lvl)
+}


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

This PR adds support for a configuration file to be provided to tugboat. A caller can now mix and match environment variables and command flags with the configuration file to execute tugboat commands.

A configuration file can be stored in either the root of the repository, a `ci` or `.ci` directory. The following file names are valid:

- `tugboat.yaml`
- `.tugboat.yaml`

### Type of change
<!-- Please chose options that are relevant for this Pull Request -->

- New feature (non-breaking change which adds functionality)
