### PR TITLE
Add the manifest create command

### DIFF
--- a/internal/cli/cmd/manifest/cmd.go
+++ b/internal/cli/cmd/manifest/cmd.go
@@ -1,0 +1,29 @@
+package manifest
+
+import (
+	"fmt"
+	"tugboat/internal/cli"
+	"tugboat/internal/pkg/flags"
+
+	"github.com/spf13/cobra"
+)
+
+func NewManifestCommand(globalFlags *flags.GlobalFlagGroup) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "manifest COMMAND",
+		Short: "Manage image manifests",
+		Long:  manifestDescription,
+		Args:  cli.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println(cmd.UsageString())
+		},
+	}
+
+	cmd.AddCommand(
+		newCreateCommand(globalFlags),
+	)
+
+	return cmd
+}
+
+var manifestDescription = `Manage image manifests`

--- a/internal/cli/cmd/manifest/create.go
+++ b/internal/cli/cmd/manifest/create.go
@@ -1,0 +1,37 @@
+package manifest
+
+import (
+	"tugboat/internal/cli"
+	"tugboat/internal/pkg/flags"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func newCreateCommand(globalFlags *flags.GlobalFlagGroup) *cobra.Command {
+	manifestCreateFlags := flags.NewManifestCreateFlagGroup()
+	imageFlags := flags.NewImageFlagsGroup()
+
+	cmd := &cobra.Command{
+		Use:   "create IMAGE",
+		Short: "Create a local annotated manifest list for pushing to a registry",
+		Args:  cli.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts := flags.ToOptions(globalFlags, manifestCreateFlags, imageFlags)
+			return createManifest(opts, args)
+		},
+	}
+
+	flags.AddFlags(cmd, manifestCreateFlags, imageFlags)
+	flags.Bind(cmd, manifestCreateFlags)
+	flags.Bind(cmd, imageFlags)
+
+	return cmd
+}
+
+func createManifest(opts *flags.Options, args []string) error {
+	log.Debugf("Manifest Create Options: %+v", opts)
+	log.Debugf("Manifest Create Args: %+v", args)
+
+	return nil
+}

--- a/internal/cli/cmd/manifest/create.go
+++ b/internal/cli/cmd/manifest/create.go
@@ -35,3 +35,14 @@ func createManifest(opts *flags.Options, args []string) error {
 
 	return nil
 }
+
+func getManifestTags(opts *flags.Options) ([]string, error) {
+	// build the list of manifests
+	var manifestTags []string
+	manifestTags = append(manifestTags, opts.Manifest.Create.Tags...)
+	if opts.Manifest.Create.Latest {
+		manifestTags = append(manifestTags, "latest")
+	}
+
+	return manifestTags, nil
+}

--- a/internal/cli/cmd/manifest/create_test.go
+++ b/internal/cli/cmd/manifest/create_test.go
@@ -1,6 +1,7 @@
 package manifest
 
 import (
+	"strings"
 	"testing"
 	"tugboat/internal/pkg/flags"
 
@@ -56,5 +57,25 @@ func Test_newCreateCommand(t *testing.T) {
 
 	if _, err := cmd.Flags().GetStringSlice("architectures"); err != nil {
 		t.Error(err)
+	}
+}
+
+func Test_getManifestTags(t *testing.T) {
+	opts := flags.Options{
+		Manifest: flags.ManifestOptions{
+			Create: flags.ManifestCreateOptions{
+				Latest: true,
+				Tags:   []string{"one", "two"},
+			},
+		},
+	}
+
+	manifestTags, _ := getManifestTags(&opts)
+
+	expectedTags := "one two latest"
+	actualTags := strings.Join(manifestTags, " ")
+
+	if expectedTags != actualTags {
+		t.Errorf("expected tags '%v', got '%v'", expectedTags, actualTags)
 	}
 }

--- a/internal/cli/cmd/manifest/create_test.go
+++ b/internal/cli/cmd/manifest/create_test.go
@@ -1,0 +1,60 @@
+package manifest
+
+import (
+	"testing"
+	"tugboat/internal/pkg/flags"
+
+	"github.com/spf13/pflag"
+)
+
+func Test_newCreateCommand(t *testing.T) {
+	globalFlags := flags.NewGlobalFlagGroup()
+	cmd := newCreateCommand(globalFlags)
+
+	// validate the description strings
+	expected := "Create a local annotated manifest list for pushing to a registry"
+	if expected != cmd.Short {
+		t.Errorf("expected %v, got %v", expected, cmd.Long)
+	}
+
+	// validate the number of commands attached to this command
+	commands := cmd.Commands()
+	expectedCommands := 0
+	actualCommands := len(commands)
+	if actualCommands != expectedCommands {
+		t.Errorf("expected commands %v, got %v", expectedCommands, actualCommands)
+	}
+
+	// validate what flags are attached to this command
+	if ok := cmd.HasLocalFlags(); !ok {
+		t.Error("expected to see flags, but there are none")
+	}
+
+	// validate the number of flags
+	expectedFlagCount := 4
+	actualFlagCount := 0
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		actualFlagCount++
+	})
+
+	if actualFlagCount != expectedFlagCount {
+		t.Errorf("expected %v flags, got %v", expectedFlagCount, actualFlagCount)
+	}
+
+	// validate each flag
+	if _, err := cmd.Flags().GetStringSlice("for"); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := cmd.Flags().GetBool("latest"); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := cmd.Flags().GetBool("push"); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := cmd.Flags().GetStringSlice("architectures"); err != nil {
+		t.Error(err)
+	}
+}

--- a/internal/cli/cmd/manifest/manifest_test.go
+++ b/internal/cli/cmd/manifest/manifest_test.go
@@ -1,0 +1,48 @@
+package manifest
+
+import (
+	"testing"
+	"tugboat/internal/pkg/flags"
+
+	"github.com/spf13/pflag"
+)
+
+func TestNewManifestCommand(t *testing.T) {
+	globalFlags := flags.NewGlobalFlagGroup()
+	cmd := NewManifestCommand(globalFlags)
+
+	// validate the description strings
+	expected := "Manage image manifests"
+	if expected != cmd.Long {
+		t.Errorf("expected %v, got %v", expected, cmd.Long)
+	}
+
+	expected = "Manage image manifests"
+	if expected != cmd.Short {
+		t.Errorf("expected %v, got %v", expected, cmd.Long)
+	}
+
+	// validate the number of commands attached to this command
+	commands := cmd.Commands()
+	expectedCommands := 1
+	actualCommands := len(commands)
+	if actualCommands != expectedCommands {
+		t.Errorf("expected commands %v, got %v", expectedCommands, actualCommands)
+	}
+
+	// validate what flags are attached to this command
+	if ok := cmd.HasLocalFlags(); ok {
+		t.Error("expected no flags, but there are flags")
+	}
+
+	// validate the number of flags
+	expectedFlagCount := 0
+	actualFlagCount := 0
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		actualFlagCount++
+	})
+
+	if actualFlagCount != expectedFlagCount {
+		t.Errorf("expected %v flags, got %v", expectedFlagCount, actualFlagCount)
+	}
+}

--- a/internal/cli/commands/commands.go
+++ b/internal/cli/commands/commands.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"tugboat/internal/cli/cmd/build"
+	"tugboat/internal/cli/cmd/manifest"
 	"tugboat/internal/cli/cmd/root"
 	"tugboat/internal/cli/cmd/version"
 	"tugboat/internal/pkg/flags"
@@ -24,6 +25,9 @@ func addCommands(cmd *cobra.Command, globalFlags *flags.GlobalFlagGroup) {
 	cmd.AddCommand(
 		// build
 		build.NewBuildCommand(globalFlags),
+
+		// manifest
+		manifest.NewManifestCommand(globalFlags),
 
 		// version
 		version.NewVersionCommand(globalFlags),

--- a/internal/cli/commands/commands_test.go
+++ b/internal/cli/commands/commands_test.go
@@ -9,7 +9,7 @@ func TestNewCli(t *testing.T) {
 
 	// validate the number of commands attached to the cli
 	commands := cli.Commands()
-	expectedNumCommands := 2 // the default completion and help commands are not counted
+	expectedNumCommands := 3 // the default completion and help commands are not counted
 	actualNumCommands := len(commands)
 	if actualNumCommands != expectedNumCommands {
 		t.Errorf("expected commands %v, got %v", expectedNumCommands, actualNumCommands)
@@ -19,6 +19,7 @@ func TestNewCli(t *testing.T) {
 	expectedCommands := []string{
 		"version",
 		"build",
+		"manifest",
 	}
 	for _, command := range commands {
 		if !contains(expectedCommands, command.Name()) {

--- a/internal/image/manifest_create.go
+++ b/internal/image/manifest_create.go
@@ -1,0 +1,139 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"tugboat/internal/pkg/docker"
+
+	"github.com/docker/docker/client"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	ErrNoProvidedTags           = errors.New("tags must be provided")
+	ErrNoSupportedArchitectures = errors.New("there are no supported architectures define")
+)
+
+type ManifestCreateOptions struct {
+	ManifestList           string
+	ManifestTags           []string
+	Push                   bool
+	SupportedArchitectures []string
+
+	Registry Registry
+	Official bool
+	DryRun   bool
+	Debug    bool
+
+	ArchOption string
+}
+
+func ManifestCreate(ctx context.Context, client *client.Client, opts ManifestCreateOptions) error {
+	if len(opts.ManifestTags) == 0 {
+		return errors.Wrap(ErrNoProvidedTags, "Create manifest failed")
+	}
+
+	if len(opts.SupportedArchitectures) == 0 {
+		return errors.Wrap(ErrNoSupportedArchitectures, "Create manifest failed")
+	}
+
+	// Generate the uri for the manifest list
+	manifestListUri, err := docker.NewUri(fmt.Sprintf("%s/%s", opts.Registry.Namespace, opts.ManifestList), &docker.UriOptions{
+		Registry: opts.Registry.ServerAddress,
+		Official: opts.Official,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Pre-pull all the image for each architecture
+	for _, arch := range opts.SupportedArchitectures {
+		for _, manifestTag := range opts.ManifestTags {
+			// Generate the tagged uri to pull
+			imageName := fmt.Sprintf("%s:%s", manifestListUri.ShortName(), manifestTag)
+			manifestTagUri, err := docker.NewUri(fmt.Sprintf("%s/%s", opts.Registry.Namespace, imageName), &docker.UriOptions{
+				Registry:   opts.Registry.ServerAddress,
+				Official:   opts.Official,
+				Arch:       arch,
+				ArchOption: toArchOption(opts.ArchOption),
+			})
+			if err != nil {
+				return err
+			}
+
+			// Pull the image
+			if err := pull(ctx, client, opts.Registry, manifestTagUri.Remote(), opts.DryRun); err != nil {
+				return err
+			}
+		}
+	}
+
+	// login to the registry (required to create a manifest)
+	loginOpts := &DockerLoginOptions{
+		ServerAddress: opts.Registry.ServerAddress,
+		Username:      opts.Registry.User.Name,
+		Password:      opts.Registry.User.Password,
+		DryRun:        opts.DryRun,
+	}
+	if err := dockerLogin(ctx, loginOpts); err != nil {
+		return err
+	}
+
+	// Generate the manifests for each desired tag
+	manifestsToPush := []*docker.Reference{}
+	for _, manifestTag := range opts.ManifestTags {
+		// Generate the tagged uri to work with
+		imageName := fmt.Sprintf("%s:%s", manifestListUri.ShortName(), manifestTag)
+		manifestTagUri, err := docker.NewUri(fmt.Sprintf("%s/%s", opts.Registry.Namespace, imageName), &docker.UriOptions{
+			Registry: opts.Registry.ServerAddress,
+			Official: opts.Official,
+		})
+		if err != nil {
+			return err
+		}
+
+		// Create the manifest
+		if err := createManifest(ctx, manifestTagUri, opts); err != nil {
+			return err
+		}
+
+		// Annotate the manifest
+		if err := annotateManifest(ctx, manifestTagUri, opts); err != nil {
+			return err
+		}
+
+		// Push the manifest
+		if opts.Push {
+			manifestsToPush = append(manifestsToPush, manifestTagUri)
+			log.Debugf("%s manifest staged to push", manifestTagUri.Remote())
+		}
+	}
+
+	if opts.Push {
+		// push all the manifests to the registry
+		for _, manifest := range manifestsToPush {
+			pushOpts := PushManifestOptions{
+				Purge:  true,
+				DryRun: opts.DryRun,
+				Debug:  opts.Debug,
+			}
+			if err := pushManifest(ctx, manifest, pushOpts); err != nil {
+				log.Errorf("pushing the manifest '%s' failed: %v", manifest.Remote(), err)
+			}
+		}
+	}
+
+	// logout of the registry
+	logoutOpts := &DockerLogoutOptions{
+		ServerAddress: opts.Registry.ServerAddress,
+		Username:      opts.Registry.User.Name,
+		Password:      opts.Registry.User.Password,
+		DryRun:        opts.DryRun,
+	}
+	if err := dockerLogout(ctx, logoutOpts); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/image/manifest_create.go
+++ b/internal/image/manifest_create.go
@@ -125,13 +125,7 @@ func ManifestCreate(ctx context.Context, client *client.Client, opts ManifestCre
 	}
 
 	// logout of the registry
-	logoutOpts := &DockerLogoutOptions{
-		ServerAddress: opts.Registry.ServerAddress,
-		Username:      opts.Registry.User.Name,
-		Password:      opts.Registry.User.Password,
-		DryRun:        opts.DryRun,
-	}
-	if err := dockerLogout(ctx, logoutOpts); err != nil {
+	if err := dockerLogout(ctx, opts.Registry.ServerAddress, opts.DryRun); err != nil {
 		return err
 	}
 

--- a/internal/image/manifest_helpers.go
+++ b/internal/image/manifest_helpers.go
@@ -1,0 +1,286 @@
+package image
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"tugboat/internal/pkg/docker"
+	"tugboat/internal/pkg/slices"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var ErrDockerLogin = errors.New("docker login error")
+var ErrDockerLogout = errors.New("docker logout error")
+var ErrCommandFailure = errors.New("command execution failed")
+
+type DockerLoginOptions struct {
+	ServerAddress string
+	Username      string
+	Password      string
+	DryRun        bool
+}
+
+type DockerLogoutOptions DockerLoginOptions
+
+type PushManifestOptions struct {
+	Purge  bool
+	DryRun bool
+	Debug  bool
+}
+
+type RmManifestOptions struct {
+	DryRun bool
+	Debug  bool
+}
+
+func dockerLogin(ctx context.Context, opts *DockerLoginOptions) error {
+	log.Infof("Logging into %v as %v", opts.ServerAddress, opts.Username)
+
+	if opts.DryRun {
+		return nil
+	}
+
+	loginCmd := []string{"login", "--username", opts.Username, "--password", opts.Password, opts.ServerAddress}
+
+	output, err := exec.Command("docker", loginCmd...).Output()
+	if err != nil {
+		log.Errorf("Docker login failed: %v", err)
+		return ErrDockerLogin
+	}
+	log.Info(string(output))
+
+	return nil
+}
+
+func dockerLogout(ctx context.Context, opts *DockerLogoutOptions) error {
+	log.Infof("Logging out of %v", opts.ServerAddress)
+
+	if opts.DryRun {
+		return nil
+	}
+
+	loginOutCmd := []string{"logout", opts.ServerAddress}
+
+	output, err := exec.Command("docker", loginOutCmd...).Output()
+	if err != nil {
+		return ErrDockerLogout
+	}
+	log.Info(string(output))
+
+	return nil
+}
+
+func createManifest(ctx context.Context, reference *docker.Reference, opts ManifestCreateOptions) error {
+	log.Infof("Creating Manifest for %v", reference.Remote())
+
+	arguments, err := getCreateArgs(reference, opts)
+	if err != nil {
+		return err
+	}
+	manifestCreateCmd := getCommand(arguments)
+
+	if err := executeCommand(manifestCreateCmd, opts.DryRun, opts.Debug); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func annotateManifest(ctx context.Context, reference *docker.Reference, opts ManifestCreateOptions) error {
+	log.Infof("Annotating Manifest for %v", reference.Remote())
+
+	annotateCommands, err := getAnnotateCommands(reference, opts)
+	if err != nil {
+		return err
+	}
+
+	for _, cmd := range annotateCommands {
+		if err := executeCommand(cmd, opts.DryRun, opts.Debug); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func pushManifest(ctx context.Context, reference *docker.Reference, opts PushManifestOptions) error {
+	log.Infof("Pushing Manifest for %v", reference.Remote())
+
+	arguments, err := getPushArgs(reference, opts)
+	if err != nil {
+		return err
+	}
+	pushCmd := getCommand(arguments)
+
+	if err := executeCommand(pushCmd, opts.DryRun, opts.Debug); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func removeManifests(ctx context.Context, references []*docker.Reference, opts RmManifestOptions) error {
+	allReferences := []string{}
+	for _, ref := range references {
+		allReferences = append(allReferences, ref.Remote())
+	}
+	log.Infof("Removing Manifests for %v", strings.Join(allReferences, " "))
+
+	arguments, err := getRmArgs(references)
+	if err != nil {
+		return err
+	}
+	pushCmd := getCommand(arguments)
+
+	if err := executeCommand(pushCmd, opts.DryRun, opts.Debug); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Helper functions
+type Command struct {
+	Command string
+	Args    []string
+}
+
+func getCommand(args []string) *Command {
+	return &Command{
+		Command: "docker",
+		Args:    args,
+	}
+}
+
+func executeCommand(cmd *Command, isDryRun bool, isDebug bool) error {
+
+	if err := validateCommand(cmd); err != nil {
+		return err
+	}
+
+	if isDebug {
+		log.Debugf("Running command: %v %v", cmd.Command, cmd.Args)
+	}
+
+	if isDryRun {
+		return nil
+	}
+
+	output, err := exec.Command(cmd.Command, cmd.Args...).Output()
+	if err != nil {
+		if isDebug {
+			log.Errorf("Failure: [%s %s] ", cmd.Command, cmd.Args)
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				if len(exitErr.Stderr) > 0 {
+					log.Debugf("Exit code: %d\n****\n%s****\n", exitErr.ExitCode(), string(exitErr.Stderr))
+				}
+			}
+			if len(output) > 0 {
+				log.Debugf("STDOUT\n****\n%s****\n", string(output))
+			}
+		} else {
+			var exitErr *exec.ExitError
+			if errors.As(err, &exitErr) {
+				if len(exitErr.Stderr) > 0 {
+					fmt.Printf("%v", string(exitErr.Stderr))
+				}
+			}
+		}
+		return ErrCommandFailure
+	}
+	return nil
+}
+
+func getCreateArgs(reference *docker.Reference, opts ManifestCreateOptions) ([]string, error) {
+	args := []string{"manifest", "create", reference.Remote()}
+
+	for _, arch := range opts.SupportedArchitectures {
+		// Generate the arch uri for the image
+		uri, err := docker.NewUri(reference.Name(), &docker.UriOptions{
+			Registry:   opts.Registry.ServerAddress,
+			Official:   opts.Official,
+			Arch:       arch,
+			ArchOption: toArchOption(opts.ArchOption),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		args = append(args, uri.Remote())
+	}
+
+	return args, nil
+
+}
+
+func getPushArgs(reference *docker.Reference, opts PushManifestOptions) ([]string, error) {
+	args := []string{"manifest", "push"}
+
+	if opts.Purge {
+		args = append(args, "--purge")
+	}
+
+	args = append(args, reference.Remote())
+
+	return args, nil
+
+}
+
+func getAnnotateCommands(reference *docker.Reference, opts ManifestCreateOptions) ([]*Command, error) {
+	var annotateCommands []*Command
+	baseArgs := []string{"manifest", "annotate", reference.Remote()}
+
+	for _, arch := range opts.SupportedArchitectures {
+		args := []string{}
+		// Generate the arch uri for the image
+		uri, err := docker.NewUri(reference.Name(), &docker.UriOptions{
+			Registry:   opts.Registry.ServerAddress,
+			Official:   opts.Official,
+			Arch:       arch,
+			ArchOption: toArchOption(opts.ArchOption),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		args = append(args, baseArgs...)
+		args = append(args, uri.Remote(), "--arch", arch)
+
+		cmd := getCommand(args)
+		annotateCommands = append(annotateCommands, cmd)
+
+	}
+	return annotateCommands, nil
+}
+
+func getRmArgs(references []*docker.Reference) ([]string, error) {
+	args := []string{"manifest", "rm"}
+
+	for _, ref := range references {
+		args = append(args, ref.Remote())
+	}
+
+	return args, nil
+}
+
+// validateCommand ensures that the command only contains expected commands so unexpected programs are not run
+func validateCommand(cmd *Command) error {
+	allowedCommands := []string{"docker"}
+	disallowedCharacters := []string{";", "|", "&"}
+
+	if !slices.Contains(allowedCommands, cmd.Command) {
+		return fmt.Errorf("disallowed command: %s", cmd.Command)
+	}
+
+	input := strings.Join(cmd.Args, " ")
+	for _, char := range disallowedCharacters {
+		if strings.Contains(input, char) {
+			return fmt.Errorf("disallowed character: %s", char)
+		}
+	}
+
+	return nil
+}

--- a/internal/image/manifest_helpers.go
+++ b/internal/image/manifest_helpers.go
@@ -23,8 +23,6 @@ type DockerLoginOptions struct {
 	DryRun        bool
 }
 
-type DockerLogoutOptions DockerLoginOptions
-
 type PushManifestOptions struct {
 	Purge  bool
 	DryRun bool
@@ -55,14 +53,14 @@ func dockerLogin(ctx context.Context, opts *DockerLoginOptions) error {
 	return nil
 }
 
-func dockerLogout(ctx context.Context, opts *DockerLogoutOptions) error {
-	log.Infof("Logging out of %v", opts.ServerAddress)
+func dockerLogout(ctx context.Context, registry string, isDryRun bool) error {
+	log.Infof("Logging out of %v", registry)
 
-	if opts.DryRun {
+	if isDryRun {
 		return nil
 	}
 
-	loginOutCmd := []string{"logout", opts.ServerAddress}
+	loginOutCmd := []string{"logout", registry}
 
 	output, err := exec.Command("docker", loginOutCmd...).Output()
 	if err != nil {

--- a/internal/image/manifest_helpers_test.go
+++ b/internal/image/manifest_helpers_test.go
@@ -1,0 +1,170 @@
+package image
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"tugboat/internal/pkg/docker"
+	"tugboat/internal/pkg/flags"
+)
+
+var (
+	image = "image"
+	tag   = "tag"
+)
+
+var basicCreateOpts = ManifestCreateOptions{
+	ManifestList:           image,
+	ManifestTags:           []string{tag},
+	Push:                   false,
+	SupportedArchitectures: []string{"arm64"},
+	Registry: NewRegistry(
+		"docker.io",
+		"namespace",
+		"username",
+		"password",
+	),
+	Official:   false,
+	DryRun:     true,
+	Debug:      false,
+	ArchOption: flags.DefaultArchOption,
+}
+
+var basicPushOpts = PushManifestOptions{
+	Purge:  true,
+	DryRun: false,
+	Debug:  false,
+}
+
+func Test_getCommand(t *testing.T) {
+	cmd := getCommand([]string{})
+
+	if cmd.Command != "docker" {
+		t.Errorf("expected command: docker, got %v", cmd.Command)
+	}
+}
+
+func Test_validateCommand(t *testing.T) {
+	testCases := []struct {
+		name        string
+		command     string
+		args        []string
+		expectedErr bool
+	}{
+		{
+			name:        "valid command",
+			command:     "docker",
+			args:        []string{"images"},
+			expectedErr: false,
+		},
+		{
+			name:        "invalid char ;",
+			command:     "docker",
+			args:        []string{"images", ";", "rm", "-rf", "./non-existent-dir"},
+			expectedErr: true,
+		},
+		{
+			name:        "invalid char |",
+			command:     "docker",
+			args:        []string{"images", "|", "something"},
+			expectedErr: true,
+		},
+		{
+			name:        "invalid char &",
+			command:     "docker",
+			args:        []string{"images", "&&", "something"},
+			expectedErr: true,
+		},
+		{
+			name:        "invalid command",
+			command:     "rm",
+			args:        []string{"-rf", "./non-existent-dir"},
+			expectedErr: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := &Command{
+				Command: tc.command,
+				Args:    tc.args,
+			}
+			err := validateCommand(cmd)
+
+			if tc.expectedErr && err == nil {
+				t.Errorf("expected command to be valid, but was invalid")
+			}
+
+			if !tc.expectedErr && err != nil {
+				t.Errorf("expected command to be invalid, but was valid")
+			}
+
+		})
+	}
+}
+
+func Test_getCreateArgs(t *testing.T) {
+	imageName := fmt.Sprintf("%s:%s", image, tag)
+	ref, _ := docker.NewUri(fmt.Sprintf("%s/%s", basicCreateOpts.Registry.Namespace, imageName), &docker.UriOptions{
+		Registry: basicCreateOpts.Registry.ServerAddress,
+		Official: basicCreateOpts.Official,
+	})
+
+	expectedArgs := "manifest create docker.io/namespace/image:tag docker.io/namespace/image:arm64-tag"
+	args, _ := getCreateArgs(ref, basicCreateOpts)
+	actualArgs := strings.Join(args, " ")
+
+	if actualArgs != expectedArgs {
+		t.Errorf("expected commands %v, got %v", expectedArgs, actualArgs)
+	}
+}
+
+func Test_getPushArgs(t *testing.T) {
+	imageName := fmt.Sprintf("%s:%s", image, tag)
+	ref, _ := docker.NewUri(fmt.Sprintf("%s/%s", basicCreateOpts.Registry.Namespace, imageName), &docker.UriOptions{
+		Registry: basicCreateOpts.Registry.ServerAddress,
+		Official: basicCreateOpts.Official,
+	})
+
+	expectedArgs := "manifest push --purge docker.io/namespace/image:tag"
+	args, _ := getPushArgs(ref, basicPushOpts)
+	actualArgs := strings.Join(args, " ")
+
+	if actualArgs != expectedArgs {
+		t.Errorf("expected commands %v, got %v", expectedArgs, actualArgs)
+	}
+}
+
+func Test_getAnnotateCommands(t *testing.T) {
+
+	imageName := fmt.Sprintf("%s:%s", image, tag)
+	ref, _ := docker.NewUri(fmt.Sprintf("%s/%s", basicCreateOpts.Registry.Namespace, imageName), &docker.UriOptions{
+		Registry: basicCreateOpts.Registry.ServerAddress,
+		Official: basicCreateOpts.Official,
+	})
+
+	expectedArgs := "manifest annotate docker.io/namespace/image:tag docker.io/namespace/image:arm64-tag --arch arm64"
+	annotateCmds, _ := getAnnotateCommands(ref, basicCreateOpts)
+	// actualArgs := strings.Join(args, " ")
+
+	actualArgs := strings.Join(annotateCmds[0].Args, " ")
+	if actualArgs != expectedArgs {
+		t.Errorf("expected commands %v, got %v", expectedArgs, actualArgs)
+	}
+
+}
+
+func Test_getRmArgs(t *testing.T) {
+	imageName := fmt.Sprintf("%s:%s", image, tag)
+	ref, _ := docker.NewUri(fmt.Sprintf("%s/%s", basicCreateOpts.Registry.Namespace, imageName), &docker.UriOptions{
+		Registry: basicCreateOpts.Registry.ServerAddress,
+		Official: basicCreateOpts.Official,
+	})
+
+	expectedArgs := "manifest rm docker.io/namespace/image:tag"
+	rmArgs, _ := getRmArgs([]*docker.Reference{ref})
+
+	actualArgs := strings.Join(rmArgs, " ")
+	if expectedArgs != actualArgs {
+		t.Errorf("expected args %v, got %v", expectedArgs, actualArgs)
+	}
+}

--- a/internal/image/pull.go
+++ b/internal/image/pull.go
@@ -1,0 +1,38 @@
+package image
+
+import (
+	"context"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	log "github.com/sirupsen/logrus"
+)
+
+func pull(ctx context.Context, client *client.Client, registry Registry, image string, isDryRun bool) error {
+	log.Infof("Pulling %s", image)
+
+	if isDryRun {
+		return nil
+	}
+
+	encodedRegistryAuth, err := encodeRegistryCredentials(registry)
+	if err != nil {
+		return err
+	}
+
+	pullOpts := types.ImagePullOptions{
+		RegistryAuth: encodedRegistryAuth,
+	}
+
+	response, err := client.ImagePull(ctx, image, pullOpts)
+	if err != nil {
+		return err
+	}
+	defer response.Close()
+
+	if err := displayResponse(response); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/pkg/flags/flags.go
+++ b/internal/pkg/flags/flags.go
@@ -60,6 +60,10 @@ func ToOptions(globalFlags *GlobalFlagGroup, f ...FlagGroup) *Options {
 		switch v := flagGroup.(type) {
 		case *BuildFlagGroup:
 			opts.Build = v.ToOptions()
+		case *ImageFlagGroup:
+			opts.Image = v.ToOptions()
+		case *ManifestCreateFlagGroup:
+			opts.Manifest.Create = v.ToOptions()
 		case *VersionFlagGroup:
 			opts.Version = v.ToOptions()
 		}

--- a/internal/pkg/flags/image_flags.go
+++ b/internal/pkg/flags/image_flags.go
@@ -1,0 +1,57 @@
+package flags
+
+var (
+	ImageNameFlag = Flag{
+		Name:       "",
+		ConfigName: "image.name",
+		Value:      "",
+		Usage:      "Set the image name",
+	}
+	ImageArchitecturesFlag = Flag{
+		Name:       "architectures",
+		Shorthand:  "a",
+		ConfigName: "image.supported-architectures",
+		Value:      []string{},
+		Usage:      "Define the supported image architectures",
+	}
+	ImageVersionFlag = Flag{
+		Name:       "",
+		ConfigName: "image.version",
+		Value:      "",
+		Usage:      "Define the version of your application",
+	}
+)
+
+type ImageFlagGroup struct {
+	ImageNameFlag          *Flag
+	ImageArchitecturesFlag *Flag
+	ImageVersionFlag       *Flag
+}
+
+func NewImageFlagsGroup() *ImageFlagGroup {
+	return &ImageFlagGroup{
+		ImageNameFlag:          &ImageNameFlag,
+		ImageArchitecturesFlag: &ImageArchitecturesFlag,
+		ImageVersionFlag:       &ImageVersionFlag,
+	}
+}
+
+func (f *ImageFlagGroup) Name() string {
+	return "Image"
+}
+
+func (f *ImageFlagGroup) Flags() []*Flag {
+	return []*Flag{f.ImageNameFlag, f.ImageArchitecturesFlag, f.ImageVersionFlag}
+}
+
+func (f *ImageFlagGroup) ToOptions() ImageOptions {
+	sanitizedVersion := getString(f.ImageVersionFlag)
+
+	opts := ImageOptions{
+		Name:                   getString(f.ImageNameFlag),
+		SupportedArchitectures: getStringSlice(f.ImageArchitecturesFlag),
+		Version:                sanitizedVersion,
+	}
+
+	return opts
+}

--- a/internal/pkg/flags/manifest_create_flags.go
+++ b/internal/pkg/flags/manifest_create_flags.go
@@ -1,0 +1,54 @@
+package flags
+
+var (
+	ManifestCreateForFlag = Flag{
+		Name:       "for",
+		ConfigName: "manifest.create.for",
+		Value:      []string{},
+		Usage:      "A list of tags to create a manifest for",
+	}
+	ManifestCreateLatestFlag = Flag{
+		Name:       "latest",
+		ConfigName: "manifest.create.latest",
+		Value:      false,
+		Usage:      "Create a manifest for the latest tag",
+	}
+	ManifestCreatePushFlag = Flag{
+		Name:       "push",
+		ConfigName: "manifest.create.push",
+		Value:      false,
+		Usage:      "Push the tagged images to an image registry",
+	}
+)
+
+type ManifestCreateFlagGroup struct {
+	ManifestCreateForFlag    *Flag
+	ManifestCreateLatestFlag *Flag
+	ManifestCreatePushFlag   *Flag
+}
+
+func NewManifestCreateFlagGroup() *ManifestCreateFlagGroup {
+	return &ManifestCreateFlagGroup{
+		ManifestCreateForFlag:    &ManifestCreateForFlag,
+		ManifestCreateLatestFlag: &ManifestCreateLatestFlag,
+		ManifestCreatePushFlag:   &ManifestCreatePushFlag,
+	}
+}
+
+func (f *ManifestCreateFlagGroup) Name() string {
+	return "ManifestCreate"
+}
+
+func (f *ManifestCreateFlagGroup) Flags() []*Flag {
+	return []*Flag{f.ManifestCreateForFlag, f.ManifestCreateLatestFlag, f.ManifestCreatePushFlag}
+}
+
+func (f *ManifestCreateFlagGroup) ToOptions() ManifestCreateOptions {
+	opts := ManifestCreateOptions{
+		Tags:   getStringSlice(f.ManifestCreateForFlag),
+		Latest: getBool(f.ManifestCreateLatestFlag),
+		Push:   getBool(f.ManifestCreatePushFlag),
+	}
+
+	return opts
+}

--- a/internal/pkg/slices/slices.go
+++ b/internal/pkg/slices/slices.go
@@ -1,0 +1,11 @@
+package slices
+
+// Contains returns true if a string slice contains a given element, false otherwise
+func Contains(slice []string, element string) bool {
+	for _, value := range slice {
+		if value == element {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pkg/slices/slices_test.go
+++ b/internal/pkg/slices/slices_test.go
@@ -1,0 +1,56 @@
+package slices
+
+import "testing"
+
+func TestContains(t *testing.T) {
+	testCases := []struct {
+		name     string
+		slice    []string
+		search   string
+		expected bool
+	}{
+		{
+			name:     "empty slice",
+			slice:    []string{},
+			search:   "foo",
+			expected: false,
+		},
+		{
+			name:     "without value",
+			slice:    []string{"foo"},
+			search:   "bar",
+			expected: false,
+		},
+		{
+			name:     "in first value",
+			slice:    []string{"foo"},
+			search:   "foo",
+			expected: true,
+		},
+		{
+			name:     "in second value",
+			slice:    []string{"foo", "bar"},
+			search:   "bar",
+			expected: true,
+		},
+		{
+			name:     "nil",
+			slice:    nil,
+			search:   "bar",
+			expected: false,
+		},
+		{
+			name:     "empty search value",
+			slice:    []string{"foo", "bar"},
+			search:   "",
+			expected: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if value := Contains(tc.slice, tc.search); value != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR adds the `manifest create` to the cli interface so that a manifest can be generated for multi-arch images

### Type of change
<!-- Please chose options that are relevant for this Pull Request -->

- New feature (non-breaking change which adds functionality)
