### PR TITLE
add a template engine

### DIFF
--- a/internal/cli/cmd/root/root_test.go
+++ b/internal/cli/cmd/root/root_test.go
@@ -36,7 +36,7 @@ func TestRootCommand(t *testing.T) {
 	}
 
 	// validate the number of flags
-	expectedFlagCount := 6
+	expectedFlagCount := 8
 	actualFlagCount := 0
 	cmd.Flags().VisitAll(func(f *pflag.Flag) {
 		actualFlagCount++

--- a/internal/cli/cmd/root/root_test.go
+++ b/internal/cli/cmd/root/root_test.go
@@ -47,6 +47,10 @@ func TestRootCommand(t *testing.T) {
 	}
 
 	// validate each flag
+	if _, err := cmd.Flags().GetString("config"); err != nil {
+		t.Error(err)
+	}
+
 	if _, err := cmd.Flags().GetBool("dry-run"); err != nil {
 		t.Error(err)
 	}
@@ -68,6 +72,10 @@ func TestRootCommand(t *testing.T) {
 	}
 
 	if _, err := cmd.Flags().GetString("docker-pass"); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := cmd.Flags().GetBool("official"); err != nil {
 		t.Error(err)
 	}
 

--- a/internal/pkg/git/git.go
+++ b/internal/pkg/git/git.go
@@ -1,0 +1,76 @@
+package git
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// IsRepo returns true if current folder is a git repository
+func IsRepo(ctx context.Context) bool {
+	output, err := Clean(Run(ctx, "rev-parse --is-inside-work-tree"))
+	return err == nil && output == "true"
+}
+
+func RunWithEnv(ctx context.Context, env []string, args ...string) (string, error) {
+	extraArgs := []string{
+		"-c", "log.showSignature=false",
+	}
+	args = append(extraArgs, args...)
+	cmd := exec.CommandContext(ctx, "git", args...)
+
+	stdout := bytes.Buffer{}
+	stderr := bytes.Buffer{}
+
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Env = append(cmd.Env, env...)
+
+	log.WithField("args", args).Debug("running git")
+	err := cmd.Run()
+
+	log.WithField("stdout", stdout.String()).
+		WithField("stderr", stderr.String()).
+		Debug("git result")
+
+	if err != nil {
+		return "", errors.New(stderr.String())
+	}
+
+	return stdout.String(), nil
+}
+
+// Run runs a git command and returns its output or errors
+func Run(ctx context.Context, args string) (string, error) {
+	splitArgs := strings.Split(args, " ")
+	return RunWithEnv(ctx, []string{}, splitArgs...)
+}
+
+// Clean cleans up the output
+func Clean(output string, err error) (string, error) {
+	output = strings.ReplaceAll(strings.Split(output, "\n")[0], "'", "")
+	if err != nil {
+		err = errors.New(strings.TrimSuffix(err.Error(), "\n"))
+	}
+	return output, err
+}
+
+// CleanAllLines returns all the non empty lines of the output, cleaned up
+func CleanAllLines(output string, err error) ([]string, error) {
+	var result []string
+	for _, line := range strings.Split(output, "\n") {
+		l := strings.TrimSpace(strings.ReplaceAll(line, "'", ""))
+		if l == "" {
+			continue
+		}
+		result = append(result, l)
+	}
+	if err != nil {
+		err = errors.New(strings.TrimSuffix(err.Error(), "\n"))
+	}
+	return result, err
+}

--- a/internal/pkg/git/git_test.go
+++ b/internal/pkg/git/git_test.go
@@ -1,0 +1,28 @@
+package git
+
+import (
+	"context"
+	"testing"
+)
+
+func TestIsRepo(t *testing.T) {
+	testCases := []struct {
+		name     string
+		expected bool
+	}{
+		{
+			name:     "is repository",
+			expected: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			actual := IsRepo(ctx)
+
+			if tc.expected != actual {
+				t.Errorf("expected %v, got %v", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/pkg/tmpl/tmpl.go
+++ b/internal/pkg/tmpl/tmpl.go
@@ -1,0 +1,93 @@
+package tmpl
+
+import (
+	"bytes"
+	"strings"
+	"text/template"
+	"time"
+	"tugboat/internal/pkg/flags"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+// Template holds data that can be applied to a template string
+type Template struct {
+	fields Fields
+}
+
+// Fields that will be available to the template engine
+type Fields map[string]interface{}
+
+const (
+	imageName   = "ImageName"
+	version     = "Version"
+	tag         = "Tag"
+	branch      = "Branch"
+	commit      = "Commit"
+	shortCommit = "ShortCommit"
+	fullCommit  = "FullCommit"
+)
+
+func New(opts *flags.Options) *Template {
+	return &Template{
+		fields: Fields{
+			imageName:   opts.Image.Name,
+			version:     opts.Image.Version,
+			tag:         opts.Global.Git.Tag,
+			branch:      opts.Global.Git.Branch,
+			commit:      opts.Global.Git.Commit,
+			shortCommit: opts.Global.Git.ShortCommit,
+			fullCommit:  opts.Global.Git.FullCommit,
+		},
+	}
+}
+
+// Apply applies the given string against the Fields stored in the template
+func (t *Template) Apply(s string) (string, error) {
+	var output bytes.Buffer
+	tmpl, err := template.New("tmpl").
+		Option("missingkey=error").
+		Funcs(template.FuncMap{
+			"replace": strings.ReplaceAll,
+			"split":   strings.Split,
+			"time": func(s string) string {
+				return time.Now().UTC().Format(s)
+			},
+			"tolower":    strings.ToLower,
+			"toupper":    strings.ToUpper,
+			"trim":       strings.TrimSpace,
+			"trimprefix": strings.TrimPrefix,
+			"trimsuffix": strings.TrimSuffix,
+			"title":      cases.Title(language.English).String,
+		}).
+		Parse(s)
+	if err != nil {
+		return "", err
+	}
+
+	err = tmpl.Execute(&output, t.fields)
+	return output.String(), err
+}
+
+// CompileStringSlice will apply a template against a slice of strings
+func CompileStringSlice(input []string, opts *flags.Options) ([]string, error) {
+	compiledItems := []string{}
+	for _, item := range input {
+		tmpl, err := New(opts).Apply(item)
+		if err != nil {
+			return nil, err
+		}
+		compiledItems = append(compiledItems, tmpl)
+	}
+	return compiledItems, nil
+}
+
+// CompileString will apply a template against a given string
+func CompileString(input string, opts *flags.Options) (string, error) {
+	tmpl, err := New(opts).Apply(input)
+	if err != nil {
+		return "", err
+	}
+	return tmpl, nil
+}

--- a/internal/pkg/tmpl/tmpl_test.go
+++ b/internal/pkg/tmpl/tmpl_test.go
@@ -1,0 +1,140 @@
+package tmpl
+
+import (
+	"testing"
+	"tugboat/internal/pkg/flags"
+)
+
+var opts = &flags.Options{
+	Global: flags.GlobalOptions{
+		Git: flags.Git{
+			Branch:      "branch",
+			Tag:         "tag",
+			Commit:      "shortCommit",
+			ShortCommit: "shortCommit",
+			FullCommit:  "fullCommit",
+		},
+	},
+	Image: flags.ImageOptions{
+		Name:    "image",
+		Version: "version",
+	},
+}
+
+func TestCompileString(t *testing.T) {
+	testCases := []struct {
+		name     string
+		template string
+		expected string
+	}{
+		{
+			name:     "docker image w/ version tag",
+			template: `{{.ImageName}}:{{.Version}}`,
+			expected: "image:version",
+		},
+		{
+			name:     "docker image w/ all git commit info",
+			template: `{{.ImageName}}:{{.Commit}}-{{.ShortCommit}}-{{.FullCommit}}`,
+			expected: "image:shortCommit-shortCommit-fullCommit",
+		},
+		{
+			name:     "docker image w/ all git branch and tag",
+			template: `{{.ImageName}}:{{.Tag}}-{{.Branch}}`,
+			expected: "image:tag-branch",
+		},
+		{
+			name:     "replace",
+			template: `{{ replace "image" "image" "another" }}`,
+			expected: "another",
+		},
+		{
+			name:     "tolower",
+			template: `{{ tolower "LOWER" }}`,
+			expected: "lower",
+		},
+		{
+			name:     "toupper",
+			template: `{{ toupper "upper" }}`,
+			expected: "UPPER",
+		},
+		{
+			name:     "trim",
+			template: `{{ printf "  trimmed  " | trim }}`,
+			expected: "trimmed",
+		},
+		{
+			name:     "trimprefix",
+			template: `{{ trimprefix "trimmed" "tr" }}`,
+			expected: "immed",
+		},
+		{
+			name:     "trimsuffix",
+			template: `{{ trimsuffix "trimmed" "med" }}`,
+			expected: "trim",
+		},
+		{
+			name:     "title",
+			template: `{{ title "title case" }}`,
+			expected: "Title Case",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			compiledString, _ := CompileString(tc.template, opts)
+
+			if tc.expected != compiledString {
+				t.Errorf("expected '%v', got '%v'", tc.expected, compiledString)
+			}
+		})
+	}
+}
+
+func TestCompileString_time(t *testing.T) {
+	testCases := []struct {
+		name     string
+		template string
+	}{
+		{
+			name:     "time YYYY-MM-DD",
+			template: `{{ time "2006-01-02" }}`,
+		},
+		{
+			name:     "time MM/DD/YYYY",
+			template: `{{ time "01/02/2006" }}`,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			compiledString, _ := CompileString(tc.template, opts)
+
+			if len(compiledString) == 0 {
+				t.Errorf("expected a time, got '%v'", compiledString)
+			}
+		})
+	}
+}
+
+func TestCompileStringSlice(t *testing.T) {
+	testCases := []struct {
+		name     string
+		template []string
+		expected []string
+	}{
+		{
+			name:     "slice",
+			template: []string{"{{.ImageName}}", "{{.Version}}", "{{.Branch}}"},
+			expected: []string{"image", "version", "branch"},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			compiledString, _ := CompileStringSlice(tc.template, opts)
+
+			for i, item := range tc.expected {
+				if item != compiledString[i] {
+					t.Errorf("expected '%v', got '%v'", tc.expected, compiledString)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR adds a template engine that can be used in commands to dynamically evaluate a set of predefined keys.

| Key                        | Description                                                |
|------------------|----------------------------------------|
| `.ImageName`    | The value from `image.name`                 |
| `.Version`            | The value derived from `image.version` |
| `.ShortCommit`  | The git commit short hash                       |
| `.FullCommit`     | The git commit full hash                           |
| `.Branch`            | The current git branch                              |
| `.Tag`                  | The current git tag                                    |

### Type of change
<!-- Please chose options that are relevant for this Pull Request -->

- Enhancement (builds on existing functionality and refactoring)
