### PR TITLE
Tag command

### DIFF
--- a/internal/cli/cmd/tag/cmd.go
+++ b/internal/cli/cmd/tag/cmd.go
@@ -1,0 +1,83 @@
+package tag
+
+import (
+	"context"
+	"tugboat/internal/cli"
+	"tugboat/internal/clients/docker"
+	"tugboat/internal/image"
+	"tugboat/internal/pkg/flags"
+	"tugboat/internal/pkg/tmpl"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+func NewTagCommand(globalFlags *flags.GlobalFlagGroup) *cobra.Command {
+	tagFlags := flags.NewTagFlagsGroup()
+	imageFlags := flags.NewImageFlagsGroup()
+
+	cmd := &cobra.Command{
+		Use:   "tag SOURCE_IMAGE",
+		Short: "Create a tag that refers to another image",
+		Long:  tagDescription,
+		Args:  cli.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts := flags.ToOptions(globalFlags, tagFlags, imageFlags)
+			return runTag(opts, args)
+		},
+	}
+
+	flags.AddFlags(cmd, tagFlags, imageFlags)
+	flags.Bind(cmd, tagFlags)
+	flags.Bind(cmd, imageFlags)
+
+	return cmd
+}
+
+var tagDescription = `Create a tag that refers to another image`
+
+func runTag(opts *flags.Options, args []string) error {
+	log.Debugf("Tag Options: %+v", opts)
+	log.Debugf("Tag Args: %+v", args)
+
+	ctx := context.Background()
+	client, err := docker.NewClientFromEnv()
+	if err != nil {
+		return err
+	}
+
+	compiledSourceImage, err := tmpl.CompileString(args[0], opts)
+	if err != nil {
+		return err
+	}
+
+	compiledTags, err := tmpl.CompileStringSlice(opts.Tag.Tags, opts)
+	if err != nil {
+		return err
+	}
+
+	log.Debugf("compiledSourceImage: %s", compiledSourceImage)
+	log.Debugf("compiledTags: %s", compiledTags)
+
+	tagOptions := image.TagOptions{
+		SourceImage:            compiledSourceImage,
+		Tags:                   compiledTags,
+		Push:                   opts.Tag.Push,
+		SupportedArchitectures: opts.Image.SupportedArchitectures,
+		Registry: image.NewRegistry(
+			opts.Global.Docker.Registry,
+			opts.Global.Docker.Namespace,
+			opts.Global.Docker.Username,
+			opts.Global.Docker.Password,
+		),
+		Official:   opts.Global.Official,
+		DryRun:     opts.Global.DryRun,
+		Debug:      opts.Global.Debug,
+		ArchOption: flags.DefaultArchOption,
+	}
+
+	if err := image.ImageTag(ctx, client, tagOptions); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/cli/cmd/tag/tag_test.go
+++ b/internal/cli/cmd/tag/tag_test.go
@@ -1,0 +1,61 @@
+package tag
+
+import (
+	"testing"
+	"tugboat/internal/pkg/flags"
+
+	"github.com/spf13/pflag"
+)
+
+func TestTagCommand(t *testing.T) {
+	globalFlags := flags.NewGlobalFlagGroup()
+	cmd := NewTagCommand(globalFlags)
+
+	// validate the description strings
+	expected := "Create a tag that refers to another image"
+	if expected != cmd.Long {
+		t.Errorf("expected %v, got %v", expected, cmd.Long)
+	}
+
+	expected = "Create a tag that refers to another image"
+	if expected != cmd.Short {
+		t.Errorf("expected %v, got %v", expected, cmd.Long)
+	}
+
+	// validate the number of commands attached to this command
+	commands := cmd.Commands()
+	expectedCommands := 0
+	actualCommands := len(commands)
+	if actualCommands != expectedCommands {
+		t.Errorf("expected commands %v, got %v", expectedCommands, actualCommands)
+	}
+
+	// validate what flags are attached to this command
+	if ok := cmd.HasLocalFlags(); !ok {
+		t.Error("expected to see flags, but there are none")
+	}
+
+	// validate the number of flags
+	expectedFlagCount := 3
+	actualFlagCount := 0
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		actualFlagCount++
+	})
+
+	if actualFlagCount != expectedFlagCount {
+		t.Errorf("expected %v flags, got %v", expectedFlagCount, actualFlagCount)
+	}
+
+	// validate each flag
+	if _, err := cmd.Flags().GetStringSlice("architectures"); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := cmd.Flags().GetStringSlice("tags"); err != nil {
+		t.Error(err)
+	}
+
+	if _, err := cmd.Flags().GetBool("push"); err != nil {
+		t.Error(err)
+	}
+}

--- a/internal/cli/commands/commands.go
+++ b/internal/cli/commands/commands.go
@@ -4,6 +4,7 @@ import (
 	"tugboat/internal/cli/cmd/build"
 	"tugboat/internal/cli/cmd/manifest"
 	"tugboat/internal/cli/cmd/root"
+	"tugboat/internal/cli/cmd/tag"
 	"tugboat/internal/cli/cmd/version"
 	"tugboat/internal/pkg/flags"
 
@@ -28,6 +29,9 @@ func addCommands(cmd *cobra.Command, globalFlags *flags.GlobalFlagGroup) {
 
 		// manifest
 		manifest.NewManifestCommand(globalFlags),
+
+		// tag
+		tag.NewTagCommand(globalFlags),
 
 		// version
 		version.NewVersionCommand(globalFlags),

--- a/internal/cli/commands/commands_test.go
+++ b/internal/cli/commands/commands_test.go
@@ -9,7 +9,7 @@ func TestNewCli(t *testing.T) {
 
 	// validate the number of commands attached to the cli
 	commands := cli.Commands()
-	expectedNumCommands := 3 // the default completion and help commands are not counted
+	expectedNumCommands := 4 // the default completion and help commands are not counted
 	actualNumCommands := len(commands)
 	if actualNumCommands != expectedNumCommands {
 		t.Errorf("expected commands %v, got %v", expectedNumCommands, actualNumCommands)
@@ -17,9 +17,10 @@ func TestNewCli(t *testing.T) {
 
 	// validate what commands are attached to the cli (the default completion and help commands are not counted)
 	expectedCommands := []string{
-		"version",
 		"build",
 		"manifest",
+		"tag",
+		"version",
 	}
 	for _, command := range commands {
 		if !contains(expectedCommands, command.Name()) {

--- a/internal/image/manifest_helpers_test.go
+++ b/internal/image/manifest_helpers_test.go
@@ -9,13 +9,13 @@ import (
 )
 
 var (
-	image = "image"
-	tag   = "tag"
+	image       = "image"
+	manifestTag = "tag"
 )
 
 var basicCreateOpts = ManifestCreateOptions{
 	ManifestList:           image,
-	ManifestTags:           []string{tag},
+	ManifestTags:           []string{manifestTag},
 	Push:                   false,
 	SupportedArchitectures: []string{"arm64"},
 	Registry: NewRegistry(
@@ -103,7 +103,7 @@ func Test_validateCommand(t *testing.T) {
 }
 
 func Test_getCreateArgs(t *testing.T) {
-	imageName := fmt.Sprintf("%s:%s", image, tag)
+	imageName := fmt.Sprintf("%s:%s", image, manifestTag)
 	ref, _ := docker.NewUri(fmt.Sprintf("%s/%s", basicCreateOpts.Registry.Namespace, imageName), &docker.UriOptions{
 		Registry: basicCreateOpts.Registry.ServerAddress,
 		Official: basicCreateOpts.Official,
@@ -119,7 +119,7 @@ func Test_getCreateArgs(t *testing.T) {
 }
 
 func Test_getPushArgs(t *testing.T) {
-	imageName := fmt.Sprintf("%s:%s", image, tag)
+	imageName := fmt.Sprintf("%s:%s", image, manifestTag)
 	ref, _ := docker.NewUri(fmt.Sprintf("%s/%s", basicCreateOpts.Registry.Namespace, imageName), &docker.UriOptions{
 		Registry: basicCreateOpts.Registry.ServerAddress,
 		Official: basicCreateOpts.Official,
@@ -136,7 +136,7 @@ func Test_getPushArgs(t *testing.T) {
 
 func Test_getAnnotateCommands(t *testing.T) {
 
-	imageName := fmt.Sprintf("%s:%s", image, tag)
+	imageName := fmt.Sprintf("%s:%s", image, manifestTag)
 	ref, _ := docker.NewUri(fmt.Sprintf("%s/%s", basicCreateOpts.Registry.Namespace, imageName), &docker.UriOptions{
 		Registry: basicCreateOpts.Registry.ServerAddress,
 		Official: basicCreateOpts.Official,
@@ -154,7 +154,7 @@ func Test_getAnnotateCommands(t *testing.T) {
 }
 
 func Test_getRmArgs(t *testing.T) {
-	imageName := fmt.Sprintf("%s:%s", image, tag)
+	imageName := fmt.Sprintf("%s:%s", image, manifestTag)
 	ref, _ := docker.NewUri(fmt.Sprintf("%s/%s", basicCreateOpts.Registry.Namespace, imageName), &docker.UriOptions{
 		Registry: basicCreateOpts.Registry.ServerAddress,
 		Official: basicCreateOpts.Official,

--- a/internal/image/tag.go
+++ b/internal/image/tag.go
@@ -1,0 +1,93 @@
+package image
+
+import (
+	"context"
+	"fmt"
+	"tugboat/internal/pkg/docker"
+
+	"github.com/docker/docker/client"
+	log "github.com/sirupsen/logrus"
+)
+
+type TagOptions struct {
+	// Should be in 'image[:tag]' format
+	SourceImage            string
+	Tags                   []string
+	Push                   bool
+	SupportedArchitectures []string
+
+	Registry Registry
+	Official bool
+	DryRun   bool
+	Debug    bool
+
+	ArchOption string
+}
+
+func ImageTag(ctx context.Context, client *client.Client, opts TagOptions) error {
+	if len(opts.Tags) == 0 {
+		return ErrNoProvidedTags
+	}
+
+	if len(opts.SupportedArchitectures) == 0 {
+		return ErrNoSupportedArchitectures
+	}
+
+	for _, arch := range opts.SupportedArchitectures {
+		// Generate the uri for the source image
+		sourceUri, err := docker.NewUri(fmt.Sprintf("%s/%s", opts.Registry.Namespace, opts.SourceImage), &docker.UriOptions{
+			Registry:   opts.Registry.ServerAddress,
+			Official:   opts.Official,
+			Arch:       arch,
+			ArchOption: toArchOption(opts.ArchOption),
+		})
+		if err != nil {
+			return err
+		}
+
+		// Pull the image for each architecture to tag
+		if err := pull(ctx, client, opts.Registry, sourceUri.Remote(), opts.DryRun); err != nil {
+			return err
+		}
+
+		for _, targetTag := range opts.Tags {
+			// Generate the uri for the target tag
+			targetUri, err := docker.NewUri(fmt.Sprintf("%v:%v", sourceUri.ShortName(), targetTag), &docker.UriOptions{
+				Registry:   opts.Registry.ServerAddress,
+				Official:   opts.Official,
+				Arch:       arch,
+				ArchOption: toArchOption(opts.ArchOption),
+			})
+			if err != nil {
+				return err
+			}
+
+			// Tag the image for each additional reference tag
+			if err := tag(ctx, client, sourceUri.Remote(), targetUri.Remote(), opts.DryRun); err != nil {
+				return err
+			}
+
+			if opts.Push {
+				// Push the tagged image
+				if err := push(ctx, client, opts.Registry, targetUri.Remote(), opts.DryRun); err != nil {
+					log.Error(err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func tag(ctx context.Context, client *client.Client, sourceImage string, targetImage string, isDryRun bool) error {
+	log.Infof("Tagging %v as %v", sourceImage, targetImage)
+
+	if isDryRun {
+		return nil
+	}
+
+	if err := client.ImageTag(ctx, sourceImage, targetImage); err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/pkg/flags/flags.go
+++ b/internal/pkg/flags/flags.go
@@ -64,6 +64,8 @@ func ToOptions(globalFlags *GlobalFlagGroup, f ...FlagGroup) *Options {
 			opts.Image = v.ToOptions()
 		case *ManifestCreateFlagGroup:
 			opts.Manifest.Create = v.ToOptions()
+		case *TagFlagGroup:
+			opts.Tag = v.ToOptions()
 		case *VersionFlagGroup:
 			opts.Version = v.ToOptions()
 		}

--- a/internal/pkg/flags/tag_flags.go
+++ b/internal/pkg/flags/tag_flags.go
@@ -1,0 +1,45 @@
+package flags
+
+var (
+	TagTagsFlag = Flag{
+		Name:       "tags",
+		ConfigName: "",
+		Value:      []string{},
+		Usage:      "A list of tags to reference the image by",
+	}
+	TagPushFlag = Flag{
+		Name:       "push",
+		ConfigName: "tag.push",
+		Value:      false,
+		Usage:      "Push the tagged images to a container registry",
+	}
+)
+
+type TagFlagGroup struct {
+	TagTagsFlag *Flag
+	TagPushFlag *Flag
+}
+
+func NewTagFlagsGroup() *TagFlagGroup {
+	return &TagFlagGroup{
+		TagTagsFlag: &TagTagsFlag,
+		TagPushFlag: &TagPushFlag,
+	}
+}
+
+func (f *TagFlagGroup) Name() string {
+	return "Tag"
+}
+
+func (f *TagFlagGroup) Flags() []*Flag {
+	return []*Flag{f.TagTagsFlag, f.TagPushFlag}
+}
+
+func (f *TagFlagGroup) ToOptions() TagOptions {
+	opts := TagOptions{
+		Tags: getStringSlice(f.TagTagsFlag),
+		Push: getBool(f.TagPushFlag),
+	}
+
+	return opts
+}


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR implements the `tugboat tag` command to allow images to be tagged after building. This command also implements usage of the template engine so that you can store some configuration options in the configuration file.

### Type of change
<!-- Please chose options that are relevant for this Pull Request -->

- New feature (non-breaking change which adds functionality)
