### PR TITLE
evaluate the version config as an env variable

### DIFF
--- a/internal/pkg/flags/image_flags.go
+++ b/internal/pkg/flags/image_flags.go
@@ -1,5 +1,7 @@
 package flags
 
+import log "github.com/sirupsen/logrus"
+
 var (
 	ImageNameFlag = Flag{
 		Name:       "",
@@ -45,7 +47,10 @@ func (f *ImageFlagGroup) Flags() []*Flag {
 }
 
 func (f *ImageFlagGroup) ToOptions() ImageOptions {
-	sanitizedVersion := getString(f.ImageVersionFlag)
+	sanitizedVersion, err := evaluateValue(getString(f.ImageVersionFlag))
+	if err != nil {
+		log.Errorf("%v: the version will not be used as expressed", err)
+	}
 
 	opts := ImageOptions{
 		Name:                   getString(f.ImageNameFlag),


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR enables the `image.version` configuration option to be set as an environment variable so that it can be evaluated at runtime.

### Type of change
<!-- Please chose options that are relevant for this Pull Request -->

- New feature (non-breaking change which adds functionality)
