### PR TITLE
add interface defining a driver for building containers

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -1,0 +1,76 @@
+package driver
+
+import (
+	"context"
+	"io"
+	"tugboat/internal/pkg/reference"
+	"tugboat/internal/registry"
+)
+
+// ImageBuilder represents the functionality for building container images
+type ImageBuilder interface {
+	BuildImage(ctx context.Context, options BuildOptions) (io.ReadCloser, error)
+	PullImage(ctx context.Context, image string) (io.ReadCloser, error)
+	PullImageWithArch(ctx context.Context, image string, architecture string) (io.ReadCloser, error)
+}
+
+// ImagePusher represents the functionality for pushing container images
+type ImagePusher interface {
+	PushImage(ctx context.Context, image string) (io.ReadCloser, error)
+	PushImageWithArch(ctx context.Context, image string, architecture string) (io.ReadCloser, error)
+	TagImage(ctx context.Context, sourceImage string, targetTag string) (string, error)
+}
+
+// ImageBuilderPusher represents the functionality for building and pushing container images
+type ImageBuilderPusher interface {
+	ImageBuilder
+	ImagePusher
+}
+
+// ManifestSet represents the functionality for working with image manifests
+type ManifestSet interface {
+	CreateManifest(ctx context.Context, options ManifestCreateOptions) (io.ReadCloser, error)
+	PushManifest(ctx context.Context, manifestList string, options ManifestPushOptions) error
+	RemoveManifest(ctx context.Context, manifestLists []string) error
+}
+
+// Driver represents the complete set of functionality provided by a container driver
+type Driver interface {
+	ImageBuilder
+	ImagePusher
+	ManifestSet
+	GetUri(tag string) (*reference.Reference, error)
+}
+
+type DriverOptions struct {
+	Debug           bool
+	DryRun          bool
+	Official        bool
+	ArchitectureTag string
+	Registry        *registry.Registry
+}
+
+type BuildOptions struct {
+	Context    string
+	Dockerfile string
+	Tags       []string
+	BuildArgs  []string
+	Rm         bool
+	Pull       bool
+	NoCache    bool
+	Push       bool
+}
+
+type PushOptions struct {
+	RegistryURL string
+}
+
+type ManifestCreateOptions struct {
+	ManifestList           string
+	ManifestTags           []string
+	SupportedArchitectures []string
+}
+
+type ManifestPushOptions struct {
+	Purge bool
+}

--- a/internal/driver/helpers.go
+++ b/internal/driver/helpers.go
@@ -1,0 +1,34 @@
+package driver
+
+import (
+	"fmt"
+	"tugboat/internal/pkg/reference"
+
+	"github.com/pkg/errors"
+)
+
+func GenerateUri(registry string, namespace string, tag string, official bool, archOption reference.ArchOption) (*reference.Reference, error) {
+	uri, err := reference.NewUri(fmt.Sprintf("%s/%s", namespace, tag), &reference.UriOptions{
+		Registry:   registry,
+		Official:   official,
+		ArchOption: archOption,
+	})
+	if err != nil {
+		return nil, errors.Errorf("%v", err)
+	}
+	return uri, nil
+}
+
+func GenerateAllUris(registry string, namespace string, tags []string, official bool, archOption reference.ArchOption) ([]*reference.Reference, error) {
+	buildTags := []*reference.Reference{}
+
+	for _, tag := range tags {
+		taggedUri, err := GenerateUri(registry, namespace, tag, official, archOption)
+		if err != nil {
+			return nil, errors.Errorf("%v", err)
+		}
+		buildTags = append(buildTags, taggedUri)
+	}
+
+	return buildTags, nil
+}


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR introduces a `Driver` interface that captures the functionality of what it takes to create a multi-arch container. This interface can be used to separate the existing logic out of the CLI and into a driver instead.

### Type of change
<!-- Please chose options that are relevant for this Pull Request -->

- New feature (non-breaking change which adds functionality)
