### PR TITLE
Improve the error message for missing registry credentials

### DIFF
--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -15,7 +15,7 @@ type RegistryUser struct {
 
 func NewRegistry(serverAddress, namespace, username, password string) (*Registry, error) {
 	if serverAddress == "" || username == "" || password == "" {
-		return nil, errors.New("invalid input parameters")
+		return nil, errors.New("invalid registry parameters: registry url, username, and password must be provided")
 	}
 
 	return &Registry{


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR improves an error message when a registry username/password is not provided

### Type of change
<!-- Please chose options that are relevant for this Pull Request -->

- Enhancement (builds on existing functionality and refactoring)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have linked the issue to the PR
