### PR TITLE
Update the internal reference package to look for a registry url to improve parsing

### DIFF
--- a/internal/pkg/reference/docker_test.go
+++ b/internal/pkg/reference/docker_test.go
@@ -1,6 +1,49 @@
 package reference
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
+
+func TestNewUri_unofficial_namespace(t *testing.T) {
+	testCases := []struct {
+		name       string
+		registry   string
+		namespace  string
+		image      string
+		archOption ArchOption
+		expected   string
+	}{
+		// registry, namespace
+		{
+			name:       "registry, duplicate namespace",
+			registry:   "localhost.local",
+			namespace:  "namespace",
+			image:      "namespace/busybox",
+			archOption: ArchOmit,
+			expected:   "localhost.local/namespace/busybox:latest",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &UriOptions{
+				Registry:   tc.registry,
+				Official:   false,
+				ArchOption: tc.archOption,
+			}
+			uri, err := NewUri(fmt.Sprintf("%s/%s", tc.namespace, tc.image), opts)
+			if err != nil {
+				t.Errorf("An unexpected error occurred: %v", err)
+			}
+
+			actual := patchArch(uri.Remote())
+
+			if tc.expected != actual {
+				t.Errorf("expected value: %v; actual value: %v", tc.expected, actual)
+			}
+		})
+	}
+}
 
 func TestNewUri_official(t *testing.T) {
 	testCases := []struct {

--- a/internal/pkg/reference/helpers.go
+++ b/internal/pkg/reference/helpers.go
@@ -23,7 +23,9 @@ func generateUriString(image string, registry string, arch string, isOfficial bo
 			namespace = s[0]
 			image = s[1]
 		} else if len(s) == 3 {
-			registry = s[0]
+			if strings.Contains(s[0], ".") {
+				registry = s[0]
+			}
 			namespace = s[1]
 			image = s[2]
 		}


### PR DESCRIPTION
### Description
<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->
This PR improves the reference package's ability to parse a string for a registry url. This should make full uris parsable when calling it's `generateUriString` function.

### Type of change
<!-- Please chose options that are relevant for this Pull Request -->

- Enhancement (builds on existing functionality and refactoring)

### Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code
- [x] I have made corresponding changes to the documentation
- [x] I have linked the issue to the PR
